### PR TITLE
extra remote capabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     coderay (1.1.0)
@@ -120,7 +120,7 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sass (3.4.3)
     simplecov (0.9.0)
       docile (~> 1.1.0)
@@ -147,7 +147,7 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    webmock (1.18.0)
+    webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
 
@@ -164,4 +164,7 @@ DEPENDENCIES
   rspec-rails (~> 2.14.0)
   simplecov-rcov (~> 0.2.3)
   sqlite3
-  webmock (~> 1.18.0)
+  webmock (~> 1.21.0)
+
+BUNDLED WITH
+   1.10.2

--- a/daylight.gemspec
+++ b/daylight.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-rails',    '~> 2.14.0'
   s.add_development_dependency 'simplecov-rcov', '~> 0.2.3'
-  s.add_development_dependency 'webmock',        '~> 1.18.0'
+  s.add_development_dependency 'webmock',        '~> 1.21.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'factory_girl'
   s.add_development_dependency 'faker'

--- a/lib/daylight/associations.rb
+++ b/lib/daylight/associations.rb
@@ -21,8 +21,8 @@ module Daylight::Associations
         "#{prefix}#{collection_name}/#{member_id}/#{reflection.name}.#{extension}"
       end
 
-      def call_remote(remoted_method, model)
-        response = get(remoted_method)
+      def call_remote(remoted_method, model, http_verb, args)
+        response = self.method(http_verb).call(remoted_method, args)
         # strip the root, but take into consideration metadata
         if Hash === response && response.has_key?(remoted_method.to_s)
           response = response[remoted_method.to_s]
@@ -213,17 +213,22 @@ module Daylight::Associations
     end
 
     ##
-    # Adds a method to the model that calls the remote action for its data.
+    # Adds a method to the model that calls the remote action that either
+    # gets or mutates data
     #
     # Example:
     #
-    #   remote :posts_by_popularity, class_name: 'post'
+    #   remote :posts_by_popularity, class_name: 'post', http_verb: :get
+    #
+    #   or
+    #
+    #   remote :posts_by_popularity, class_name: 'post', http_verb: :patch
     #
 
     def remote name, options
       create_reflection(:remote, name, options).tap do |reflection|
-        define_cached_method reflection.name do
-          call_remote(reflection.name, reflection.klass)
+        define_cached_method(reflection.name) do |args=nil|
+          call_remote(reflection.name, reflection.klass, reflection.options[:http_verb], args)
         end
       end
     end
@@ -235,7 +240,7 @@ module Daylight::Associations
         define_method(uncached_method_name, block)
 
         # define the cached wrapper around the uncached method
-        define_method method_name do
+        define_method method_name do |args=nil|
           ivar_name  = :"@#{method_name}"
           cache_key  = options[:cache_key] || method_name
           attributes = options.has_key?(:index) ? @attributes[options[:index]] : @attributes
@@ -246,7 +251,11 @@ module Daylight::Associations
             if attributes.include?(cache_key)
               load_attributes_for(method_name, attributes[cache_key])
             else
-              send(uncached_method_name)
+              if args
+                send(uncached_method_name, args)
+              else
+                send(uncached_method_name)
+              end
             end
 
           # Track of the association hashcode for changes

--- a/rails/daylight/refiners.rb
+++ b/rails/daylight/refiners.rb
@@ -17,9 +17,13 @@ module Daylight::Refiners
     public_send(name)
   end
 
-  def remoted method
+  def remoted(method, body=nil)
     raise ArgumentError, "Unknown remote: #{method}" unless self.class.remoted?(method)
-    public_send(method)
+    if body.blank?
+      public_send(method)
+    else
+      public_send(method, body)
+    end
   end
 
   ##
@@ -174,7 +178,7 @@ module Daylight::Refiners
       with_helper(params) do |helper|
         self.
           find(params[:id]).
-          remoted(helper.remoted_params)
+          remoted(helper.remoted_params, params[:body])
       end
     end
 

--- a/rails/extensions/route_options.rb
+++ b/rails/extensions/route_options.rb
@@ -23,8 +23,11 @@ module RouteOptions
         end
 
         remoted.each do |remote|
-          model_class.add_remoted(remote) if model_class
-          get remote, to: "#{parent_resource.name}#remoted", defaults: {remoted: remote}, as: remote
+          split_remote = remote.to_s.split('_', 2)
+          verb = split_remote[0]
+          remote_method_name = split_remote[1]
+          model_class.add_remoted(remote_method_name) if model_class
+          self.method(verb).call(remote_method_name, to: "#{parent_resource.name}#remoted", defaults: {remoted: remote_method_name}, as: remote_method_name)
         end
       end
 

--- a/spec/lib/daylight/associations_spec.rb
+++ b/spec/lib/daylight/associations_spec.rb
@@ -10,18 +10,19 @@ describe Daylight::Associations do
     self.include_format_in_path = false
 
     has_many   :related_test_classes
-    has_many   :things,        class_name: 'RelatedTestClass'
-    belongs_to :parent,        class_name: 'RelatedTestClass'
-    has_one    :grandparent,   class_name: 'RelatedTestClass', through: :parent
-    has_one    :associate,     class_name: 'RelatedTestClass'
-    remote     :remote_stuff,  class_name: 'RelatedTestClass'
+    has_many   :things,       class_name: 'RelatedTestClass'
+    belongs_to :parent,       class_name: 'RelatedTestClass'
+    has_one    :grandparent,  class_name: 'RelatedTestClass', through: :parent
+    has_one    :associate,    class_name: 'RelatedTestClass'
+    remote     :remote_stuff, class_name: 'RelatedTestClass', http_verb: :get
 
     def id;        123; end
     def parent_id; 456; end
   end
 
   class AnotherAssociationTestClass < Daylight::API
-    belongs_to :parent, class_name: 'RelatedTestClass'
+    belongs_to :parent,   class_name: 'RelatedTestClass'
+    remote :patch_remote, class_name: 'AnotherAssociationTestClass', http_verb: :patch
   end
 
   describe :has_many do
@@ -258,51 +259,68 @@ describe Daylight::Associations do
 
   describe :remote do
 
-    def respond_with(data)
-      stub_request(:get, %r{#{AssociationsTestClass.site}}).to_return(body: data.to_json)
+    context 'get' do
+      def respond_with(http_verb, data)
+        stub_request(http_verb, %r{#{AssociationsTestClass.site}}).to_return(body: data.to_json)
+      end
+
+      let(:subject)  { AssociationsTestClass.new }
+
+      it "loads data from the remote" do
+        respond_with(:get, {remote_stuff: {id: 2, foo: 'bar'}})
+
+        subject.remote_stuff.foo.should == 'bar'
+      end
+
+      it "handles collections" do
+        respond_with(:get, {remote_stuff: [{id: 2, foo: 'first'}, {id: 3, foo: 'second'}]})
+
+        subject.remote_stuff.first.foo.should == 'first'
+        subject.remote_stuff.last.foo.should == 'second'
+      end
+
+      it "caches the data" do
+        respond_with(:get, {remote_stuff: {cache: 'cachey cache'}})
+
+        subject.should_receive(:get).once.and_call_original
+
+        subject.remote_stuff.cache.should == 'cachey cache'
+        subject.remote_stuff.cache.should == 'cachey cache'
+      end
+
+      it "handles metadata with an object" do
+        respond_with(:get, {remote_stuff: {id: 2, foo: 'bar'}, meta: {}})
+
+        subject.remote_stuff.foo.should == 'bar'
+      end
+
+      it "handles metadata with a collection" do
+        respond_with(:get, {remote_stuff: [{id: 2, foo: 'first'}, {id: 3, foo: 'second'}], meta: {}})
+
+        subject.remote_stuff.first.foo.should == 'first'
+        subject.remote_stuff.last.foo.should == 'second'
+      end
+
+      it "returns data from the attributes if that already exists" do
+        subject.attributes[:remote_stuff] = 'wibble'
+
+        subject.remote_stuff.should == 'wibble'
+      end
     end
 
-    let(:subject) { AssociationsTestClass.new }
+    context 'patch' do
+      def respond_with(http_verb, data)
+        stub_request(http_verb, %r{#{AnotherAssociationTestClass.site}}).to_return(:body => data.to_json)
+      end
 
-    it "loads data from the remote" do
-      respond_with({remote_stuff: {id: 2, foo: 'bar'}})
+      let(:subject)  { AnotherAssociationTestClass.new }
 
-      subject.remote_stuff.foo.should == 'bar'
-    end
+      it "responds successfully from the remote" do
+        stub = respond_with(:patch, {patch_remote: {id: 2}})
+        subject.patch_remote({data: 'foo', more_data: 'bar'})
 
-    it "handles collections" do
-      respond_with({remote_stuff: [{id: 2, foo: 'first'}, {id: 3, foo: 'second'}]})
-
-      subject.remote_stuff.first.foo.should == 'first'
-      subject.remote_stuff.last.foo.should == 'second'
-    end
-
-    it "caches the data" do
-      respond_with({remote_stuff: {cache: 'cachey cache'}})
-
-      subject.should_receive(:get).once.and_call_original
-
-      subject.remote_stuff.cache.should == 'cachey cache'
-      subject.remote_stuff.cache.should == 'cachey cache'
-    end
-
-    it "handles metadata with an object" do
-      respond_with({remote_stuff: {id: 2, foo: 'bar'}, meta: {}})
-
-      subject.remote_stuff.foo.should == 'bar'
-    end
-
-    it "handles metadata with a collection" do
-      respond_with({remote_stuff: [{id: 2, foo: 'first'}, {id: 3, foo: 'second'}], meta: {}})
-
-      subject.remote_stuff.first.foo.should == 'first'
-      subject.remote_stuff.last.foo.should == 'second'
-    end
-
-    it "returns data from the attributes if that already exists" do
-      subject.attributes[:remote_stuff] = 'wibble'
-
-      subject.remote_stuff.should == 'wibble'
+        expect(stub).to have_been_requested
+      end
     end
 
   end

--- a/spec/rails/daylight/api_controller_spec.rb
+++ b/spec/rails/daylight/api_controller_spec.rb
@@ -313,7 +313,7 @@ describe Daylight::APIController, type: :controller do
 
     before do
       @routes.draw do
-        resources :suites, associated: [:cases], remoted: [:odd_cases], controller: :suites
+        resources :suites, associated: [:cases], remoted: [:get_odd_cases], controller: :suites
       end
     end
 

--- a/spec/rails/extensions/route_options_spec.rb
+++ b/spec/rails/extensions/route_options_spec.rb
@@ -236,7 +236,7 @@ describe RouteOptions, type: [:controller, :routing] do
 
     before do
       @routes.draw do
-        resources :test_method_route, remoted: %w[foo]
+        resources :test_method_route, remoted: %w[get_foo]
       end
     end
 
@@ -267,42 +267,73 @@ describe RouteOptions, type: [:controller, :routing] do
   end
 
   describe "remoted resource with alternate model" do
-    # rspec's controller temporarily wipes out routes and recreates
-    # routes for the anonymnous controller, we don't want to do that
-    # also, rspec-rails does not honor the tests(controller) function
     def self.controller_class
       TestMethodRouteAltModelController
     end
 
-    before do
-      @routes.draw do
-        resources :test_method_route_alt_model, remoted: %w[bar]
+    context 'get' do
+      # rspec's controller temporarily wipes out routes and recreates
+      # routes for the anonymnous controller, we don't want to do that
+      # also, rspec-rails does not honor the tests(controller) function
+      before do
+        @routes.draw do
+          resources :test_method_route_alt_model, remoted: %w[get_bar]
+        end
+      end
+
+      it 'adds associated route' do
+        expect(get: '/test_method_route_alt_model/1/bar').to route_to(
+          controller: 'test_method_route_alt_model',
+          action: 'remoted',
+          id: '1',
+          remoted: 'bar'
+        )
+      end
+
+      it 'responds to method with expected params' do
+        get :remoted, id: 1, remoted: 'bar'
+
+        assert_response :success
+
+        response.body.should == 'test_method_route_alt_model/1/bar'
+      end
+
+      it 'sets up named link helpers' do
+        bar_test_method_route_alt_model_path(10).should == '/test_method_route_alt_model/10/bar'
+      end
+
+      it 'keeps track for remoted methods on the controller' do
+        TestAltModel.remoted?(:bar).should be_true
       end
     end
 
-    it 'adds associated route' do
-      expect(get: '/test_method_route_alt_model/1/bar').to route_to(
-        controller: 'test_method_route_alt_model',
-        action: 'remoted',
-        id: '1',
-        remoted: 'bar'
-      )
-    end
+    context 'patch' do
+      before do
+        @routes.draw do
+          resources :test_method_route_alt_model, remoted: %w[patch_bar]
+        end
+      end
 
-    it 'respsonds to method with expected params' do
-      get :remoted, id: 1, remoted: 'bar'
+      it 'adds associated route' do
+        expect(patch: '/test_method_route_alt_model/1/bar').to route_to(
+          controller: 'test_method_route_alt_model',
+          action: 'remoted',
+          id: '1',
+          remoted: 'bar'
+        )
+      end
 
-      assert_response :success
+      it 'responds to method with expected params' do
+        patch :remoted, id: 1, remoted: 'bar'
 
-      response.body.should == 'test_method_route_alt_model/1/bar'
-    end
+        assert_response :success
 
-    it 'sets up named link helpers' do
-      bar_test_method_route_alt_model_path(10).should == '/test_method_route_alt_model/10/bar'
-    end
+        response.body.should == 'test_method_route_alt_model/1/bar'
+      end
 
-    it 'keeps track for remoted methods on the controller' do
-      TestAltModel.remoted?(:bar).should be_true
+      it 'keeps track for remoted methods on the controller' do
+        TestAltModel.remoted?(:bar).should be_true
+      end
     end
   end
 


### PR DESCRIPTION
some refactoring for daylight's remote capabilities:

first thing: allows for setting up routes to be any verb you need `patch` `get` etc. with prefixing the method name like so:

```
resources :events, remoted: [:patch_remote_enqueue, :patch_remote_start]
```

this will NOT affect the method names. this is only for generating the appropriate routes 

second thing: the way to define remote methods in the client is like so: (note the new verb keyword)

```
remote :remote_enqueue,   class_name: 'API::ADMIN::Event', verb: :patch
```

third thing: you should now be able to send arguments over to the methods on the other end like so:

```
something.remote_enqueue(arg1: :kewl, arg2: :superkewl)
```

fourth thing: wherever your dealing with the `remoted` method in your server side controller, if you're going to be mutating data (PATCH/POST, etc) you'll be passing a body, and to do so, you'll need to permit the attributes like so: 

```
def remoted
  render(
    json: self.collection = model.remoted(passable_params),
    root: remoted_params
  )
end

private

def passable_params
  #body here is the keyword necessary for daylight to recognize your 
    parameters
  where_params.merge(
    body: params.permit(
      :attr1,
      :attr2
    )
  )
end
```

which will make a PATCH request based on the verb you previously selected
