### PR TITLE
has-many association should use attributes

### DIFF
--- a/lib/daylight/resource_proxy.rb
+++ b/lib/daylight/resource_proxy.rb
@@ -28,7 +28,11 @@ class Daylight::ResourceProxy
   ##
   # Loads records from server based on current paremeters and from URL
   def load
-    resource_class.find(:all, params: to_params, from: @from)
+    if association_resource && association_resource.attributes[association_name]
+      association_resource.attributes[association_name]
+    else
+      resource_class.find(:all, params: to_params, from: @from)
+    end
   end
 
   ##


### PR DESCRIPTION
when an association `has_many` of something, it should evaluate the attributes that come in the payload instead of making new queries
